### PR TITLE
Fix gitignore and find tools.jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ build
 run
 /MineTweaker3-Web/nbproject/private/
 /MineTweaker3-Web/doc
-/MineTweaker3-MC164-Main/eclipse
+eclipse/
 /ZenScript-Test

--- a/configuration.gradle
+++ b/configuration.gradle
@@ -1,10 +1,12 @@
+import javax.tools.ToolProvider
 // #######################
 // ### Global settings ###
 // #######################
 
 ext.mineTweakerVersion = "3.0.9C"
 ext.mineTweakerDebug = "false"
-ext.javaToolsJar = new File("C:/Program Files/Java/jdk1.8.0_05/lib/tools.jar")
+//ext.javaToolsJar = new File("C:/Program Files/Java/jdk1.8.0_05/lib/tools.jar")
+ext.javaToolsJar = ((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()
 
 // ######################
 // ### 1.6.4 settings ###

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,8 @@ The MineTweaker 3 source is setup as a multi-project Gradle project:
 
 ### Developing and running MineTweaker from source
 
-Configuration settings are stored in configuration.gradle . *Make sure to configure the tools.jar directory in that file! Nothing will compile without it.*
+Configuration settings are stored in configuration.gradle . *If buildSrc fails to compile you might have to edit the
+`javaToolsJar` location in `configuration.gradle`*
 
 In order to use the project, you have to execute the setupDecompWorkspaceAll (or use setupDecomWorkspace17X if you have errors on the 1.6.4 forge patches). It will prepare all the subprojects for you. After that, you can simply run minecraft with the runClient task in MineTweaker3-XYZ-Main project, which will run MineTweaker (without mod support). Likewise, you can use the runClient task on any of its mod support library subprojects, which will run MineTweaker with only the mod support for that specific mod.
 


### PR DESCRIPTION
- The gitignore only ignored the eclipse files in one directory...
- I found a new way to find the `tools.jar`. [[ref]](http://stackoverflow.com/a/28805423/2035962) [[ref]](https://docs.oracle.com/javase/7/docs/api/javax/tools/ToolProvider.html#getSystemToolClassLoader()). This is available in Java 1.6.