### PR TITLE
Tweaks for MCLiquidStack

### DIFF
--- a/MineTweaker3-MC164-Main/src/main/java/minetweaker/mc164/liquid/MCLiquidDefinition.java
+++ b/MineTweaker3-MC164-Main/src/main/java/minetweaker/mc164/liquid/MCLiquidDefinition.java
@@ -125,6 +125,30 @@ public class MCLiquidDefinition implements ILiquidDefinition {
 		MineTweakerAPI.apply(new RemoveContainerAction(filled));
 	}
 	
+	@Override
+	public boolean equals(Object obj) {
+		if(this == obj)
+			return true;
+		
+		if(obj == null)
+			return false;
+		
+		if(this.getClass() != obj.getClass())
+			return false;
+		
+		MCLiquidDefinition liquidDefintion = (MCLiquidDefinition)obj;
+		
+		if((!this.getName().equals(liquidDefintion.getName())) || 
+			this.getLuminosity() != liquidDefintion.getLuminosity() ||
+			this.getDensity() != liquidDefintion.getDensity() ||
+			this.getTemperature() != liquidDefintion.getTemperature() ||
+			this.getViscosity() != liquidDefintion.getViscosity() ||
+			this.isGaseous() != liquidDefintion.isGaseous())
+			return false;
+		
+		return true;
+	}
+	
 	// #######################
 	// ### Private methods ###
 	// #######################

--- a/MineTweaker3-MC164-Main/src/main/java/minetweaker/mc164/liquid/MCLiquidStack.java
+++ b/MineTweaker3-MC164-Main/src/main/java/minetweaker/mc164/liquid/MCLiquidStack.java
@@ -117,7 +117,7 @@ public class MCLiquidStack implements ILiquidStack {
 	
 	@Override
 	public String toString() {
-		return "<fluid:" + this.getName() + ">";
+		return "<liquid:" + this.getName() + ">";
 	}
 	
 	// ##################################

--- a/MineTweaker3-MC164-Main/src/main/java/minetweaker/mc164/liquid/MCLiquidStack.java
+++ b/MineTweaker3-MC164-Main/src/main/java/minetweaker/mc164/liquid/MCLiquidStack.java
@@ -115,6 +115,11 @@ public class MCLiquidStack implements ILiquidStack {
 		return stack;
 	}
 	
+	@Override
+	public String toString() {
+		return "<fluid:" + this.getName() + ">";
+	}
+	
 	// ##################################
 	// ### IIngredient implementation ###
 	// ##################################

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/liquid/MCLiquidDefinition.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/liquid/MCLiquidDefinition.java
@@ -117,7 +117,7 @@ public class MCLiquidDefinition implements ILiquidDefinition {
 	}
 	
 	@Override
-	public boolean equals(Object ) {
+	public boolean equals(Object obj) {
 		if(this == obj)
 			return true;
 		

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/liquid/MCLiquidDefinition.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/liquid/MCLiquidDefinition.java
@@ -116,6 +116,30 @@ public class MCLiquidDefinition implements ILiquidDefinition {
 		MineTweakerAPI.logError("Cannot remove container items in MineCraft 1.7.X");
 	}
 	
+	@Override
+	public boolean equals(Object ) {
+		if(this == obj)
+			return true;
+		
+		if(obj == null)
+			return false;
+		
+		if(this.getClass() != obj.getClass())
+			return false;
+		
+		MCLiquidDefinition liquidDefintion = (MCLiquidDefinition)obj;
+		
+		if((!this.getName().equals(liquidDefintion.getName())) || 
+			this.getLuminosity() != liquidDefintion.getLuminosity() ||
+			this.getDensity() != liquidDefintion.getDensity() ||
+			this.getTemperature() != liquidDefintion.getTemperature() ||
+			this.getViscosity() != liquidDefintion.getViscosity() ||
+			this.isGaseous() != liquidDefintion.isGaseous())
+			return false;
+		
+		return true;
+	}
+	
 	// #######################
 	// ### Private methods ###
 	// #######################

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/liquid/MCLiquidStack.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/liquid/MCLiquidStack.java
@@ -117,7 +117,7 @@ public class MCLiquidStack implements ILiquidStack {
 	
 	@Override
 	public String toString() {
-		return "<fluid:" + this.getName() + ">";
+		return "<liquid:" + this.getName() + ">";
 	}
 	
 	// ##################################

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/liquid/MCLiquidStack.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/liquid/MCLiquidStack.java
@@ -115,6 +115,11 @@ public class MCLiquidStack implements ILiquidStack {
 		return stack;
 	}
 	
+	@Override
+	public String toString() {
+		return "<fluid:" + this.getName() + ">";
+	}
+	
 	// ##################################
 	// ### IIngredient implementation ###
 	// ##################################

--- a/MineTweaker3-MC172-Main/src/main/java/minetweaker/mc172/liquid/MCLiquidDefinition.java
+++ b/MineTweaker3-MC172-Main/src/main/java/minetweaker/mc172/liquid/MCLiquidDefinition.java
@@ -116,6 +116,30 @@ public class MCLiquidDefinition implements ILiquidDefinition {
 		MineTweakerAPI.logError("Cannot remove container items in MineCraft 1.7.X");
 	}
 	
+	@Override
+	public boolean equals(Object obj) {
+		if(this == obj)
+			return true;
+		
+		if(obj == null)
+			return false;
+		
+		if(this.getClass() != obj.getClass())
+			return false;
+		
+		MCLiquidDefinition liquidDefintion = (MCLiquidDefinition)obj;
+		
+		if((!this.getName().equals(liquidDefintion.getName())) || 
+			this.getLuminosity() != liquidDefintion.getLuminosity() ||
+			this.getDensity() != liquidDefintion.getDensity() ||
+			this.getTemperature() != liquidDefintion.getTemperature() ||
+			this.getViscosity() != liquidDefintion.getViscosity() ||
+			this.isGaseous() != liquidDefintion.isGaseous())
+			return false;
+		
+		return true;
+	}
+	
 	// #######################
 	// ### Private methods ###
 	// #######################

--- a/MineTweaker3-MC172-Main/src/main/java/minetweaker/mc172/liquid/MCLiquidStack.java
+++ b/MineTweaker3-MC172-Main/src/main/java/minetweaker/mc172/liquid/MCLiquidStack.java
@@ -117,7 +117,7 @@ public class MCLiquidStack implements ILiquidStack {
 	
 	@Override
 	public String toString() {
-		return "<fluid:" + this.getName() + ">";
+		return "<liquid:" + this.getName() + ">";
 	}
 	
 	// ##################################

--- a/MineTweaker3-MC172-Main/src/main/java/minetweaker/mc172/liquid/MCLiquidStack.java
+++ b/MineTweaker3-MC172-Main/src/main/java/minetweaker/mc172/liquid/MCLiquidStack.java
@@ -115,6 +115,11 @@ public class MCLiquidStack implements ILiquidStack {
 		return stack;
 	}
 	
+	@Override
+	public String toString() {
+		return "<fluid:" + this.getName() + ">";
+	}
+	
 	// ##################################
 	// ### IIngredient implementation ###
 	// ##################################


### PR DESCRIPTION
- Added ```equals()``` method in class MCLiquidDefinition to fix a bug where the method ```matches()``` in class MCLiquidStack always returns false.
- Added ```toString()``` method in class MCLiquidStack to get a proper String representation

Fix for issue #191