### PR TITLE
Add stat methods to player api

### DIFF
--- a/MineTweaker3-API/src/main/java/minetweaker/api/player/IPlayer.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/api/player/IPlayer.java
@@ -61,6 +61,12 @@ public interface IPlayer {
 	@ZenMethod
 	public void give(IItemStack stack);
 
+	@ZenMethod
+	public int getStat(String name);
+
+	@ZenMethod
+	public void setStat(String name, int value);
+
 	// not an exposed method. risks abuse
 	public void openBrowser(String url);
 

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/player/MCPlayer.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/player/MCPlayer.java
@@ -20,6 +20,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.IChatComponent;
+import net.minecraft.stats.StatBase;
+import net.minecraft.stats.StatList;
 
 /**
  *
@@ -142,5 +144,33 @@ public class MCPlayer implements IPlayer {
 	@Override
 	public void give(IItemStack stack) {
 		player.inventory.addItemStackToInventory(MineTweakerMC.getItemStack(stack).copy());
+	}
+
+	@Override
+	public int getStat(String name) {
+		if (!(player instanceof EntityPlayerMP)) {
+			return 0;
+		}
+		EntityPlayerMP player_mp = (EntityPlayerMP) player;
+		StatBase stat = StatList.func_151177_a(name);
+		if (stat == null) {
+			MineTweakerAPI.logError("not a valid stat name: " + name);
+			return 0;
+		}
+		return player_mp.func_147099_x().writeStat(stat);
+	}
+
+	@Override
+	public void setStat(String name, int value) {
+		if (!(player instanceof EntityPlayerMP)) {
+			return;
+		}
+		EntityPlayerMP player_mp = (EntityPlayerMP) player;
+		StatBase stat = StatList.func_151177_a(name);
+		if (stat == null) {
+			MineTweakerAPI.logError("not a valid stat name: " + name);
+			return;
+		}
+		player_mp.func_147099_x().func_150873_a(player_mp, stat, value);
 	}
 }

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/server/ServerPlayer.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/server/ServerPlayer.java
@@ -123,4 +123,14 @@ public class ServerPlayer implements IPlayer {
 	public void give(IItemStack stack) {
 
 	}
+
+	@Override
+	public int getStat(String name) {
+		return 0;
+	}
+
+	@Override
+	public void setStat(String name, int value) {
+		return;
+	}
 }

--- a/MineTweaker3-MC18-Main/src/main/java/minetweaker/mc18/player/MCPlayer.java
+++ b/MineTweaker3-MC18-Main/src/main/java/minetweaker/mc18/player/MCPlayer.java
@@ -20,6 +20,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.IChatComponent;
+import net.minecraft.stats.StatBase;
+import net.minecraft.stats.StatList;
 
 /**
  *
@@ -142,5 +144,33 @@ public class MCPlayer implements IPlayer {
 	@Override
 	public void give(IItemStack stack) {
 		player.inventory.addItemStackToInventory(MineTweakerMC.getItemStack(stack).copy());
+	}
+
+	@Override
+	public int getStat(String name) {
+		if (!(player instanceof EntityPlayerMP)) {
+			return 0;
+		}
+		EntityPlayerMP player_mp = (EntityPlayerMP) player;
+		StatBase stat = StatList.getOneShotStat(name);
+		if (stat == null) {
+			MineTweakerAPI.logError("not a valid stat name: " + name);
+			return 0;
+		}
+		return player_mp.getStatFile().readStat(stat);
+	}
+
+	@Override
+	public void setStat(String name, int value) {
+		if (!(player instanceof EntityPlayerMP)) {
+			return;
+		}
+		EntityPlayerMP player_mp = (EntityPlayerMP) player;
+		StatBase stat = StatList.getOneShotStat(name);
+		if (stat == null) {
+			MineTweakerAPI.logError("not a valid stat name: " + name);
+			return;
+		}
+		player_mp.getStatFile().func_150873_a(player_mp, stat, value);
 	}
 }

--- a/MineTweaker3-MC18-Main/src/main/java/minetweaker/mc18/server/ServerPlayer.java
+++ b/MineTweaker3-MC18-Main/src/main/java/minetweaker/mc18/server/ServerPlayer.java
@@ -124,4 +124,14 @@ public class ServerPlayer implements IPlayer {
 	public void give(IItemStack stack) {
 
 	}
+
+	@Override
+	public int getStat(String name) {
+		return 0;
+	}
+
+	@Override
+	public void setStat(String name, int value) {
+		return;
+	}
 }


### PR DESCRIPTION
I have added `getStat` and `setStat` methods to IPlayer and implemented them.
The following code snippet is an example of what this feature can do:
```
recipes.addShapeless(<minecraft:dirt>, [
      <minecraft:dirt>
      ], function(output, inputs, crafting) {
        if (crafting.player.getStat("stat.deaths")<3){
          return <minecraft:iron_sword>;
        } else if (crafting.player.getStat("achievement.theEnd2")>0){
          return <minecraft:diamond>;
        } else {
          return <minecraft:dirt>.withTag({display: {Name: "Don't craft it", Lore: ["Kill the dragon and try!"]}});
        }
      }
);
```
I believe this feature will make something like 'progressive crafting' possible. Although the disadvantage is that the crafting result in a crafting table may be a bit confusing since it can not be decided on the client side.