### PR TITLE
Fix nested foreach loop cause out of index

### DIFF
--- a/ZenScript/src/main/java/stanhebben/zenscript/statements/StatementForeach.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/statements/StatementForeach.java
@@ -57,5 +57,6 @@ public class StatementForeach extends Statement {
 		body.compile(local);
 		iterator.compilePostIterate(localVariables, exit, repeat);
 		methodOutput.label(exit);
+		iterator.compileEnd();
 	}
 }


### PR DESCRIPTION
What to fix:
Nested foreach loop cause 'java.lang.ArrayIndexOutOfBoundsException'

---
How to reproduce:

```
import minetweaker.data.IData;

val d = ["a", "b", "c"] as IData[];
for i, s in d {
  print(i);
  for j, ss in d {
    print(j);
  }
}
```
---
Error message:
https://gist.github.com/skydark/174d5c96a3df4ec17902

---
How to fix:

One line and self-explanatory.