### PR TITLE
Several bug fixes and enhancements on ZenScripts

### DIFF
--- a/MineTweaker3-API/src/main/java/minetweaker/runtime/MTTweaker.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/runtime/MTTweaker.java
@@ -128,7 +128,7 @@ public class MTTweaker implements ITweaker {
 				while (script.next()) {
 					Reader reader = null;
 					try {
-						reader = new InputStreamReader(new BufferedInputStream(script.open()));
+						reader = new InputStreamReader(new BufferedInputStream(script.open()), "UTF-8");
 
 						String filename = script.getName();
 						String className = extractClassName(filename);

--- a/ZenScript/src/main/java/stanhebben/zenscript/ZenTokener.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/ZenTokener.java
@@ -95,7 +95,7 @@ public class ZenTokener extends TokenStream {
 	private static final String[] REGEXPS = {
 			"#[^\n]*[\n\\e]",
 			"//[^\n]*[\n\\e]",
-			"/\\*[^\\*]*(\\*[^/]*)*\\*/",
+			"/\\*[^\\*]*(\\*|\\*[^/\\*][^\\*]*)*\\*/",
 			"[ \t\r\n]*",
 			"[a-zA-Z_][a-zA-Z_0-9]*",
 			"\\-?(0|[1-9][0-9]*)\\.[0-9]+([eE][\\+\\-]?[0-9]+)?",

--- a/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionJavaLambda.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionJavaLambda.java
@@ -90,6 +90,7 @@ public class ExpressionJavaLambda extends Expression {
 		for (Statement statement : statements) {
 			statement.compile(environmentMethod);
 		}
+		output.ret();
 		output.end();
 
 		environment.putClass(clsName, cw.toByteArray());

--- a/ZenScript/src/main/java/stanhebben/zenscript/parser/NFA.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/parser/NFA.java
@@ -21,6 +21,10 @@ public class NFA {
 	public static final int NOFINAL = Integer.MIN_VALUE;
 	public static final int EPSILON = Integer.MIN_VALUE + 1;
 
+	/* UNICODE_ESCAPE should be between 128 and 256, so unicode chars can be
+		matched by regexp like '.' and '[^a]' and not by '[a-zA-Z]' */
+	public static final int UNICODE_ESCAPE = 256;
+
 	private final NFAState initial;
 
 	private HashMap<NodeSet, DFA.DFAState> converted;
@@ -318,6 +322,8 @@ public class NFA {
 	/* Processes a single character */
 	private int processChar(CharStream stream) {
 		if (stream.optional('\\')) {
+			if (stream.optional('u'))
+				return UNICODE_ESCAPE;
 			if (stream.optional('e'))
 				return -1;
 			if (stream.optional('r'))

--- a/ZenScript/src/main/java/stanhebben/zenscript/parser/TokenStream.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/parser/TokenStream.java
@@ -212,12 +212,17 @@ public class TokenStream implements Iterator<Token> {
 			StringBuilder value = new StringBuilder();
 			int tLine = line;
 			int tLineOffset = lineOffset;
-			while (dfa.transitions[state].containsKey(nextChar)) {
-				value.append((char) nextChar);
-				state = dfa.transitions[state].get(nextChar);
+			int _fakeNextChar = nextChar > 127 ? NFA.UNICODE_ESCAPE : nextChar;
+			while (dfa.transitions[state].containsKey(_fakeNextChar)) {
+				if (nextChar < 0)
+					value.append((char) nextChar);
+				else
+					value.appendCodePoint(nextChar);
+				state = dfa.transitions[state].get(_fakeNextChar);
 				line = reader.line;
 				lineOffset = reader.lineOffset;
 				nextChar = reader.read();
+				_fakeNextChar = nextChar > 127 ? NFA.UNICODE_ESCAPE : nextChar;
 			}
 
 			if (line < 0)

--- a/ZenScript/src/main/java/stanhebben/zenscript/statements/Statement.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/statements/Statement.java
@@ -26,7 +26,10 @@ public abstract class Statement {
 			}
 			case T_RETURN: {
 				parser.next();
-				ParsedExpression expression = ParsedExpression.read(parser, environment);
+				ParsedExpression expression = null;
+				if (parser.peek() != null && !parser.isNext(T_SEMICOLON)) {
+					expression = ParsedExpression.read(parser, environment);
+				}
 				parser.required(T_SEMICOLON, "; expected");
 				return new StatementReturn(next.getPosition(), returnType, expression);
 			}

--- a/ZenScript/src/main/java/stanhebben/zenscript/statements/StatementForeach.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/statements/StatementForeach.java
@@ -57,5 +57,6 @@ public class StatementForeach extends Statement {
 		body.compile(local);
 		iterator.compilePostIterate(localVariables, exit, repeat);
 		methodOutput.label(exit);
+		iterator.compileEnd();
 	}
 }

--- a/ZenScript/src/main/java/stanhebben/zenscript/type/expand/ZenExpandMember.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/type/expand/ZenExpandMember.java
@@ -77,12 +77,12 @@ public class ZenExpandMember {
 
 		@Override
 		public Expression eval(IEnvironmentGlobal environment) {
-			return new ExpressionCallVirtual(position, environment, getter, value.eval(environment));
+			return new ExpressionCallStatic(position, environment, getter, value.eval(environment));
 		}
 
 		@Override
 		public Expression assign(ZenPosition position, IEnvironmentGlobal environment, Expression other) {
-			return new ExpressionCallVirtual(position, environment, setter, value.eval(environment), other);
+			return new ExpressionCallStatic(position, environment, setter, value.eval(environment), other);
 		}
 
 		@Override


### PR DESCRIPTION
These are my recent works on zenscripts. These changes should not break any existing scripts.
I have explained my changes in the commit comments. If they are not very clear due to my poor English, feel free to ask any questions. For convenience, I write a summary in  following:

#### Fix nested foreach loop cause out of index:
You can reproduce this bug by the following zenscript code:
```javascript
import minetweaker.data.IData;
val d = ["a", "b", "c"] as IData[];
for i, s in d {
  print(i);
  for j, ss in d {
    print(j);
  }
}
```
It caused by a missing part while compiling for each loop.

#### Add unicode support for zenscripts
This commit add unicode support in comments and strings in zenscript.
This is a simple work around by recognizing all unicode characters as one special character while doing transitions between DFA states.

#### Add support to return void in a function
In this commit I added `return;` as a valid syntax. It is rejected by parser before. I know this is a new syntax feature that should be disscussed, but it should have no harm, uh?
Also I made all functions that did not have return statements have the return type `void`. I have to admit that this is also a I-believe-it-no-harm feature...
OK, let me explain my motivation.
Before this commit, a lambda function like following will cause errors(`Control flow falls through code end`) while running compiled bytecodes, which was caused by no bytecode of return generated in compiled lambda functions:
```javascript
import my.custom.extension.Event;
Event.onDrop(function (e) {
do.nothing();
// return;
};
anything.other();
```
So before this commit, you couldn't write your custom extensions that accept functions which have a return type of void - you couldn't write `return;` since it was a syntax error, but you also couldn't have no returns since it was a runtime error, of course you couldn't return other values since it was a casting error.

#### Fix block comments regexp 
This should fix the problem that comments like this could not be recognized:
```
/* blah blah * <- a star blah blah  / <- this slash failed */
```
A simple regular expression fix in the tokenizer.

#### Fix ZenGetter and ZenSetter annotations 
This is a trouble for the extension writers. You were not able to define an actually working `ZenGetter/ZenSetter` in a class with annotation `ZenExpansion`. The reason is that `ZenExpansion` requires static methods, but `ZenGetter/ZenSetter` in `ZenExpansion` were invoked as virtuals.