### PR TITLE
Add a new command '/mt items', to dump damage/meta based sub-items to log. Fixes #305.

### DIFF
--- a/MineTweaker3-API/src/main/java/minetweaker/MineTweakerImplementationAPI.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/MineTweakerImplementationAPI.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import static minetweaker.MineTweakerAPI.server;
 import minetweaker.api.block.IBlock;
 import minetweaker.api.block.IBlockDefinition;
+import minetweaker.api.data.DataMap;
 import minetweaker.api.data.IData;
 import minetweaker.api.entity.IEntityDefinition;
 import minetweaker.api.event.IEventHandle;
@@ -136,9 +137,14 @@ public class MineTweakerImplementationAPI {
 						Collections.sort(items, ITEMSTACK_COMPARATOR);
 						for (IItemStack stack : items) {
 							String displayName;
+							String tag = new String("");
 
 							try {
 								displayName = ", " + stack.getDisplayName();
+								IData tagData = stack.getTag();
+								if (tagData != null && tagData != DataMap.EMPTY) {
+									tag = tagData.toString();
+								}
 							} catch (Throwable ex) {
 								// some mods (such as buildcraft) may throw
 								// exceptions when calling
@@ -149,7 +155,12 @@ public class MineTweakerImplementationAPI {
 								displayName = " -- Name could not be retrieved due to an error: " + ex;
 							}
 
-							MineTweakerAPI.logCommand("<" + stack.getDefinition().getId() + ":" + stack.getDamage() + ">" + displayName);
+							if (tag.equals("")) {
+								MineTweakerAPI.logCommand("<" + stack.getDefinition().getId() + ":" + stack.getDamage() + ">" + displayName);
+							} else {
+								MineTweakerAPI.logCommand("<" + stack.getDefinition().getId() + ":" +
+									stack.getDamage() + ">.withTag(" + tag + ")" + displayName);
+							}
 						}
 
 						if (player != null) {

--- a/MineTweaker3-API/src/main/java/minetweaker/MineTweakerImplementationAPI.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/MineTweakerImplementationAPI.java
@@ -62,7 +62,7 @@ public class MineTweakerImplementationAPI {
 	private static final Map<String, MineTweakerCommand> minetweakerCommands;
 
 	private static final Comparator<IItemDefinition> ITEM_COMPARATOR = new ItemComparator();
-    private static final Comparator<IItemStack> ITEMSTACK_COMPARATOR = new ItemStackComparator();
+	private static final Comparator<IItemStack> ITEMSTACK_COMPARATOR = new ItemStackComparator();
 	private static final Comparator<ILiquidDefinition> LIQUID_COMPARATOR = new LiquidComparator();
 	private static final Comparator<IBlockDefinition> BLOCK_COMPARATOR = new BlockComparator();
 	private static final Comparator<IEntityDefinition> ENTITY_COMPARATOR = new EntityComparator();
@@ -128,7 +128,7 @@ public class MineTweakerImplementationAPI {
 				new String[] {
 						"/minetweaker items",
 						"    Outputs a list of most items in the game to the minetweaker log",
-                        "    including damage/meta based subitems (using NEI's algorithm)."
+						"    including damage/meta based subitems (using NEI's algorithm)."
 				}, new ICommandFunction() {
 					@Override
 					public void execute(String[] arguments, IPlayer player) {
@@ -819,14 +819,14 @@ public class MineTweakerImplementationAPI {
 		}
 	}
 
-    private static class ItemStackComparator implements Comparator<IItemStack> {
-        @Override
-        public int compare(IItemStack o1, IItemStack o2) {
-            int id = o1.getDefinition().getId().compareTo(o2.getDefinition().getId());
-            if (id != 0) return id;
-            return Integer.compare(o1.getDamage(), o2.getDamage());
-        }
-    }
+	private static class ItemStackComparator implements Comparator<IItemStack> {
+		@Override
+		public int compare(IItemStack o1, IItemStack o2) {
+			int id = o1.getDefinition().getId().compareTo(o2.getDefinition().getId());
+			if (id != 0) return id;
+			return Integer.compare(o1.getDamage(), o2.getDamage());
+		}
+	}
 
 	private static class LiquidComparator implements Comparator<ILiquidDefinition> {
 		@Override

--- a/MineTweaker3-API/src/main/java/minetweaker/MineTweakerImplementationAPI.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/MineTweakerImplementationAPI.java
@@ -219,7 +219,7 @@ public class MineTweakerImplementationAPI {
 										IItemStack out = shapeless.getOutput();
 										MineTweakerAPI.logError("Could not dump recipe for " + out, ex);
 									} else {
-										MineTweakerAPI.logError("Could not dump recipe", ex)
+										MineTweakerAPI.logError("Could not dump recipe", ex);
 									}
 								}
 							}

--- a/MineTweaker3-API/src/main/java/minetweaker/api/game/IGame.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/api/game/IGame.java
@@ -4,6 +4,7 @@ import java.util.List;
 import minetweaker.api.block.IBlockDefinition;
 import minetweaker.api.entity.IEntityDefinition;
 import minetweaker.api.item.IItemDefinition;
+import minetweaker.api.item.IItemStack;
 import minetweaker.api.liquid.ILiquidDefinition;
 import minetweaker.api.world.IBiome;
 import stanhebben.zenscript.annotations.ZenClass;
@@ -18,12 +19,20 @@ import stanhebben.zenscript.annotations.ZenMethod;
 @ZenClass("minetweaker.game.IGame")
 public interface IGame {
 	/**
-	 * Retrieves the item definitions in this game.
+	 * Retrieves the items in this game, not including damage/meta based subitems.
 	 * 
 	 * @return game items
 	 */
 	@ZenGetter("items")
 	public List<IItemDefinition> getItems();
+
+	/**
+	 * Retrieves the item definitions in this game, including most damage/meta based subitems.
+	 *
+	 * @return game itemstacks
+	 */
+	@ZenGetter("itemstacks")
+	public List<IItemStack> getItemStacks();
 
 	/**
 	 * Retrieves the block definitions in this game.

--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/game/MCGame.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/game/MCGame.java
@@ -6,18 +6,23 @@
 
 package minetweaker.mc1710.game;
 
-import cpw.mods.fml.common.registry.EntityRegistry;
-import cpw.mods.fml.common.registry.LanguageRegistry;
+import java.lang.StringBuilder;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import cpw.mods.fml.common.registry.EntityRegistry;
+import cpw.mods.fml.common.registry.LanguageRegistry;
+
 import minetweaker.IUndoableAction;
 import minetweaker.MineTweakerAPI;
 import minetweaker.api.block.IBlockDefinition;
 import minetweaker.api.entity.IEntityDefinition;
 import minetweaker.api.game.IGame;
 import minetweaker.api.item.IItemDefinition;
+import minetweaker.api.item.IItemStack;
 import minetweaker.api.liquid.ILiquidDefinition;
 import minetweaker.api.minecraft.MineTweakerMC;
 import minetweaker.api.world.IBiome;
@@ -25,12 +30,16 @@ import minetweaker.api.world.IBiome;
 // import minetweaker.mc1710.GuiCannotRemodify;
 import minetweaker.mc1710.entity.MCEntityDefinition;
 import minetweaker.mc1710.item.MCItemDefinition;
+import minetweaker.mc1710.item.MCItemStack;
 import minetweaker.mc1710.liquid.MCLiquidDefinition;
 import minetweaker.mc1710.util.MineTweakerHacks;
 import minetweaker.mc1710.util.MineTweakerPlatformUtils;
+
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.IIcon;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 
@@ -55,6 +64,83 @@ public class MCGame implements IGame {
 			result.add(new MCItemDefinition(item, (Item) Item.itemRegistry.getObject(item)));
 		}
 		return result;
+	}
+
+	@Override
+	public List<IItemStack> getItemStacks() {
+		// This code gratuitously stolen from NEI's ItemList.java
+		List<IItemStack> result = new ArrayList<IItemStack>();
+		List<IItemStack> perms  = new ArrayList<IItemStack>();
+		HashSet<Item> bad = new HashSet<Item>();
+
+		for (Item item : (Iterable<Item>) Item.itemRegistry) {
+			if (item == null || bad.contains(item)) {
+				continue;
+			}
+
+			try {
+				perms = getPermutations(item);
+				if (!perms.isEmpty()) {
+					result.addAll(perms);
+				}
+			} catch (Throwable ex) {
+				bad.add(item);
+				MineTweakerAPI.getLogger().logError("Failed to get permutations for " + item, ex);
+			}
+		}
+		return result;
+	}
+
+	private List<IItemStack> getPermutations(Item item) {
+		// This code gratuitously stolen from NEI's ItemList.java
+		// NOTE: we don't try to look up NEI's itemOverrides or itemVariants.
+
+		List<IItemStack> perms  = new ArrayList<IItemStack>();
+		List<ItemStack> subitems = new ArrayList<ItemStack>();
+		item.getSubItems(item, null, subitems);
+		if (!subitems.isEmpty()) {
+			for (ItemStack stack : subitems) {
+				perms.add(new MCItemStack(stack));
+			}
+			return perms;
+		}
+
+		// Search through damage values 0-15 for items with different icons.
+		HashSet<String> seen = new HashSet<String>();
+		for (int damage = 0; damage < 16; damage++) {
+			try {
+				ItemStack stack = new ItemStack(item, 1, damage);
+				IIcon icon = item.getIconIndex(stack);
+				String name = getDisplayName(stack);
+				String s = name + "@" + (icon == null ? 0 : icon.hashCode());
+				if (!seen.contains(s)) {
+					seen.add(s);
+					perms.add(new MCItemStack(stack));
+				}
+			} catch (Throwable ex) {
+				MineTweakerAPI.getLogger().logError("Skipping " + item + ":" + damage, ex);
+			}
+		}
+		return perms;
+	}
+
+	private String getDisplayName(ItemStack stack) {
+		// This code gratuitously stolen from NEI's GuiContainerManager.java
+		List<String> tooltip = null;
+		try {
+			tooltip = stack.getTooltip(Minecraft.getMinecraft().thePlayer, false);
+		} catch (Throwable ignored) {}
+
+		if (tooltip == null || tooltip.size() == 0 || tooltip.get(0) == null || tooltip.get(0) == "") {
+			return "Unnamed";
+		}
+		StringBuilder name = new StringBuilder();
+		for (String line : tooltip) {
+			// We're only using this for hashset purposes so don't
+			// need to bother with appending '#'.
+			name.append(line);
+		}
+		return name.toString();
 	}
 
 	@Override


### PR DESCRIPTION
I've built and tested this for 1.7.10 but I have not done so for 1.8.9. Thus far all semicolons in place ;-)

Example output:

```
<AWWayofTime:AlchemicalWizardrybloodRune:0>, Blood Rune
<AWWayofTime:AlchemicalWizardrybloodRune:1>, Rune of Augmented Capacity
<AWWayofTime:AlchemicalWizardrybloodRune:2>, Rune of Dislocation
<AWWayofTime:AlchemicalWizardrybloodRune:3>, Rune of the Orb
<AWWayofTime:AlchemicalWizardrybloodRune:4>, Rune of Superior Capacity
<AWWayofTime:AlchemicalWizardrybloodRune:5>, Rune of Acceleration
<AWWayofTime:AlchemicalWizardrytile.blockSpellEffect:0>, Crucible of Fire
<AWWayofTime:AlchemicalWizardrytile.blockSpellEffect:1>, Ice Maker
<AWWayofTime:AlchemicalWizardrytile.blockSpellEffect:2>, Wind Generator
<AWWayofTime:AlchemicalWizardrytile.blockSpellEffect:3>, Earth Former
```

@Blue64 I believe this is dumping localized names using getDisplayName(), but I have not tried changing my system locale to verify this. If you can't build a .jar yourself for testing, I stuck one on drive:

https://drive.google.com/file/d/0B8F2NbxuGb8FTnhZcDBRVzVSemc/view?usp=sharing

Cheers,
--fluffle
