### PR TITLE
api: MineTweakerImplementationAPI: Add missed ";" operator

### DIFF
--- a/MineTweaker3-API/src/main/java/minetweaker/MineTweakerImplementationAPI.java
+++ b/MineTweaker3-API/src/main/java/minetweaker/MineTweakerImplementationAPI.java
@@ -219,7 +219,7 @@ public class MineTweakerImplementationAPI {
 										IItemStack out = shapeless.getOutput();
 										MineTweakerAPI.logError("Could not dump recipe for " + out, ex);
 									} else {
-										MineTweakerAPI.logError("Could not dump recipe", ex)
+										MineTweakerAPI.logError("Could not dump recipe", ex);
 									}
 								}
 							}


### PR DESCRIPTION
During building another mod that uses the MineTweaker API for version 1.7.10 minecraft, I came across an error message:
```
/home/connor41/ImmersiveEngineering/build/sources/java/minetweaker/MineTweakerImplementationAPI.java:222: error: ';' expected
                                                                                MineTweakerAPI.logError("Could not dump recipe", ex)
                                                                                                                                    ^

```
Add missed ";" operator to the `MineTweaker3-API/src/main/java/minetweaker/MineTweakerImplementationAPI.java` file.
