### PR TITLE
aggressive handling of special characters in naming

### DIFF
--- a/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/brackets/ItemBracketHandler.java
+++ b/MineTweaker3-MC1710-Main/src/main/java/minetweaker/mc1710/brackets/ItemBracketHandler.java
@@ -41,7 +41,7 @@ public class ItemBracketHandler implements IBracketHandler {
 	static {
 		itemNames = new HashMap<String, Item>();
 		for (String itemName : (Set<String>) Item.itemRegistry.getKeys()) {
-			itemNames.put(itemName.replace(" ", ""), (Item) Item.itemRegistry.getObject(itemName));
+			itemNames.put(itemName.replaceAll("[^[_\p{Alnum}]]", ""), (Item) Item.itemRegistry.getObject(itemName));
 		}
 	}
 	


### PR DESCRIPTION
Replace all the things in ItemBracketHandler.

Actually, the preferred solution would be to just properly handle these cases.
Will fix issues with, for example, Tinkers-Defense Queen's Gold






I found this patch when I was reviewing old code in my forks. See if it's useful for you or not. If I remember correctly, there were issues with some items that use special characters in their name. According to my comment, Tinkers-Defense (from 1.7.10) was the culprit. Apart from that, I don't remember much about this.